### PR TITLE
chore(tasks): use remote tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,7 +174,7 @@ dist
 # Finder (MacOS) folder config
 .DS_Store
 
-# turbo 
+# turbo
 .turbo
 
 # API extractor
@@ -203,3 +203,6 @@ ehthumbs.db
 # Build info and cache
 *.tsbuildinfo
 .eslintcache
+
+# Setup artifacts
+.task/

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -2,17 +2,18 @@ version: "3"
 output: interleaved
 dotenv: [".env.local"]
 
+
+includes:
+  index: https://raw.githubusercontent.com/livekit-examples/index/main/taskfile.yaml
+
 tasks:
   post_create:
     desc: "Runs after this template is instantiated as a Sandbox or Bootstrap"
     cmds:
-      - echo -e "To setup and run the agent:\r\n"
-      - echo -e "    cd {{.ROOT_DIR}}\r"
-      - echo -e "    pnpm install\r"
-      - echo -e "    pnpm build\r"
-      - echo -e "    node dist/agent.js dev\r\n"
+      - task: index:help_setup_node_pnpm
+      - task: index:help_deploy_agent
 
   install:
     desc: "Bootstrap application for local development"
     cmds:
-      - "pnpm install"
+      - task: index:dev_node_pnpm


### PR DESCRIPTION
This patch updates the taskfile to use the remote tasks defined in the [index](https://github.com/livekit-examples/index/blob/main/taskfile.yaml) to allow us to update common tasks from a single source of truth. 

It also adds some messaging on agent deployment, so that once we go GA, users will get a nice little helper message after bootstrapping an agent template:

```
To setup and run locally:

    cd <my-app>
    pnpm install
    pnpm build
    pnpm dev

To deploy your agent to LiveKit cloud:

    lk agent create

```

Depends on https://github.com/livekit/livekit-cli/pull/625, and leaving as a draft until launch time.