### PR TITLE
Fix Cloud crashloop by downloading model files as runtime user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,6 @@ COPY . .
 # Your package.json must contain a "build" script, such as `"build": "tsc"`
 RUN pnpm build
 
-# Pre-download any ML models or files the agent needs
-# This ensures the container is ready to run immediately without downloading
-# dependencies at runtime, which improves startup time and reliability
-# Your package.json must contain a "download-files" script, such as `"download-files": "pnpm run build && node dist/agent.js download-files"`
-RUN pnpm download-files
-
 # Remove dev dependencies for a leaner production image
 RUN pnpm prune --prod
 
@@ -71,6 +65,11 @@ WORKDIR /app
 COPY --from=build --chown=appuser:appuser /app /app
 
 USER appuser
+
+# Pre-download any ML models or files the agent needs
+# This ensures the container is ready to run immediately without downloading
+# dependencies at runtime, which improves startup time and reliability
+RUN node dist/main.js download-files
 
 # Set Node.js to production mode
 ENV NODE_ENV=production


### PR DESCRIPTION
## What changed

- Moved the `download-files` step out of the Docker build stage and into the runtime stage of `Dockerfile`.
- Removed build-stage `RUN pnpm download-files`.
- Added `RUN node dist/main.js download-files` after `USER appuser`.

## Why

Resolves #30 

The agent was crashing in LiveKit Cloud because turn-detector model files were downloaded under the root user cache (`/root/.cache/...`) during build, but the worker runs as `appuser` and looks in `/app/.cache/...` at runtime.  
This mismatch caused missing model files (`model_q8.onnx`) and startup failure (`CrashLoop`).

## Result

- Model artifacts are now cached under the same user/home directory used at runtime.
- Agent startup no longer fails due to missing turn-detector files in Cloud deployments.

<img width="423" height="153" alt="agent-status" src="https://github.com/user-attachments/assets/8b49917e-1fdc-4d92-97d7-37a1efe44fa7" />

## Validation

- Deployment logs previously showed missing cache/model errors and runner initialization timeout.
- With this change, runtime download path and runtime user are aligned, which resolves the cache-location mismatch causing the crash.