### PR TITLE
Use UserData generic for typed process-level userData

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,4 @@
 import {
-  type JobContext,
-  type JobProcess,
   ServerOptions,
   cli,
   defineAgent,
@@ -19,11 +17,15 @@ import { Agent } from './agent';
 // when running locally or self-hosting your agent server.
 dotenv.config({ path: '.env.local' });
 
-export default defineAgent({
-  prewarm: async (proc: JobProcess) => {
+interface ProcessUserData {
+  vad: silero.VAD;
+}
+
+export default defineAgent<ProcessUserData>({
+  prewarm: async (proc) => {
     proc.userData.vad = await silero.VAD.load();
   },
-  entry: async (ctx: JobContext) => {
+  entry: async (ctx) => {
     // Set up a voice AI pipeline using OpenAI, Cartesia, Deepgram, and the LiveKit turn detector
     const session = new voice.AgentSession({
       // Speech-to-text (STT) is your agent's ears, turning the user's speech into text that the LLM can understand
@@ -49,7 +51,7 @@ export default defineAgent({
       // VAD and turn detection are used to determine when the user is speaking and when the agent should respond
       // See more at https://docs.livekit.io/agents/build/turns
       turnDetection: new livekit.turnDetector.MultilingualModel(),
-      vad: ctx.proc.userData.vad! as silero.VAD,
+      vad: ctx.proc.userData.vad,
       voiceOptions: {
         // Allow the LLM to generate a response while waiting for the end of turn
         preemptiveGeneration: true,


### PR DESCRIPTION
## Description
Use the new `UserData` generic on `defineAgent` to type `proc.userData`, replacing explicit `JobProcess`/`JobContext` type annotations and removing the need for type assertions.

## Changes Made
- Add `ProcessUserData` interface to define the shape of `proc.userData`
- Pass `ProcessUserData` as a generic to `defineAgent<ProcessUserData>()`
- Remove explicit `JobProcess`/`JobContext` type annotations on callback params, relying on inference
- Remove `! as silero.VAD` cast on `ctx.proc.userData.vad` since the type is now inferred
- Remove unused `JobContext` and `JobProcess` type imports

## Pre-Review Checklist
- [x] **Build passes**: All builds (lint, typecheck, tests) pass locally
- [x] **AI-generated code reviewed**: Removed unnecessary comments and ensured code quality
- [x] **Changes explained**: All changes are properly documented and justified above
- [x] **Scope appropriate**: All changes relate to the PR title, or explanations provided for why they're included

## Testing
- [x] All tests pass

## Additional Notes
Depends on the `UserData` generic added to `defineAgent`, `JobProcess`, and `JobContext` in `@livekit/agents`.

---
**Note to reviewers**: Please ensure the pre-review checklist is completed before starting your review.