### PR TITLE
move the LLM instance directly to Assistant to make it cleaner to share with tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,5 @@
     "@livekit/plugins-ai-coustics": "^0.2.10",
     "dotenv": "^17.4.1",
     "zod": "^3.25.76"
-  },
-  "pnpm": {
-    "overrides": {
-      "openai": "<6.36.0"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "@livekit/agents": "^1.3.0",
-    "@livekit/agents-plugin-livekit": "^1.3.0",
-    "@livekit/agents-plugin-silero": "^1.3.0",
-    "@livekit/plugins-ai-coustics": "^0.2.10",
+    "@livekit/agents": "^1.4.0",
+    "@livekit/agents-plugin-livekit": "^1.4.0",
+    "@livekit/agents-plugin-silero": "^1.4.0",
+    "@livekit/plugins-ai-coustics": "^0.2.12",
     "dotenv": "^17.4.1",
     "zod": "^3.25.76"
   }

--- a/package.json
+++ b/package.json
@@ -40,5 +40,10 @@
     "@livekit/plugins-ai-coustics": "^0.2.10",
     "dotenv": "^17.4.1",
     "zod": "^3.25.76"
+  },
+  "pnpm": {
+    "overrides": {
+      "openai": "<6.36.0"
+    }
   }
 }

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -1,7 +1,7 @@
 import { dedent, inference, initializeLogger, voice } from '@livekit/agents';
 import dotenv from 'dotenv';
 import { afterEach, beforeEach, describe, it } from 'vitest';
-import { AGENT_MODEL, Agent } from './agent';
+import { Agent } from './agent';
 
 dotenv.config({ path: '.env.local' });
 
@@ -11,20 +11,18 @@ initializeLogger({ pretty: true, level: 'warn' });
 
 describe('agent evaluation', () => {
   let session: voice.AgentSession;
-  let agentLlm: inference.LLM;
   let judgeLlm: inference.LLM;
 
   beforeEach(async () => {
-    agentLlm = new inference.LLM({ model: AGENT_MODEL });
-    // The judge LLM can be a cheaper model since it only evaluates agent responses
-    judgeLlm = new inference.LLM({ model: 'openai/gpt-4.1-mini' });
-    session = new voice.AgentSession({ llm: agentLlm });
+    // We can use a different LLM to evaluate the agent's responses than the one used in the agent itself
+    // This allows you to use reasoning capabilities or larger models than would be practical for realtime chat
+    judgeLlm = new inference.LLM({ model: 'openai/gpt-5.2' });
+    session = new voice.AgentSession();
     await session.start({ agent: new Agent() });
   });
 
   afterEach(async () => {
     await session?.close();
-    await agentLlm?.aclose();
     await judgeLlm?.aclose();
   });
 

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -15,7 +15,7 @@ describe('agent evaluation', () => {
 
   beforeEach(async () => {
     judgeLlm = new inference.LLM({ model: 'openai/gpt-4.1-mini' });
-    session = new voice.AgentSession({});
+    session = new voice.AgentSession();
     await session.start({ agent: new Agent() });
   });
 

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -15,8 +15,7 @@ describe('agent evaluation', () => {
 
   beforeEach(async () => {
     // We can use a different LLM to evaluate the agent's responses than the one used in the agent itself
-    // This allows you to use reasoning capabilities or larger models than would be practical for realtime chat
-    judgeLlm = new inference.LLM({ model: 'openai/gpt-5.2' });
+    judgeLlm = new inference.LLM({ model: 'openai/gpt-4.1-mini' });
     session = new voice.AgentSession({});
     await session.start({ agent: new Agent() });
   });

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -17,7 +17,7 @@ describe('agent evaluation', () => {
     // We can use a different LLM to evaluate the agent's responses than the one used in the agent itself
     // This allows you to use reasoning capabilities or larger models than would be practical for realtime chat
     judgeLlm = new inference.LLM({ model: 'openai/gpt-5.2' });
-    session = new voice.AgentSession();
+    session = new voice.AgentSession({});
     await session.start({ agent: new Agent() });
   });
 

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -14,7 +14,6 @@ describe('agent evaluation', () => {
   let judgeLlm: inference.LLM;
 
   beforeEach(async () => {
-    // We can use a different LLM to evaluate the agent's responses than the one used in the agent itself
     judgeLlm = new inference.LLM({ model: 'openai/gpt-4.1-mini' });
     session = new voice.AgentSession({});
     await session.start({ agent: new Agent() });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,6 +1,4 @@
-import { dedent, voice } from '@livekit/agents';
-
-export const AGENT_MODEL = 'openai/gpt-5.2-chat-latest';
+import { dedent, inference, voice } from '@livekit/agents';
 
 // Define a custom voice AI assistant by extending the base Agent class
 export class Agent extends voice.Agent {
@@ -12,6 +10,19 @@ export class Agent extends voice.Agent {
         Your responses are concise, to the point, and without any complex formatting or punctuation including emojis, asterisks, or other symbols.
         You are curious, friendly, and have a sense of humor.
       `,
+
+      // A Large Language Model (LLM) is your agent's brain, processing user input and generating a response
+      // See all available models at https://docs.livekit.io/agents/models/llm/
+      llm: new inference.LLM({ model: 'openai/gpt-5.2-chat-latest' }),
+
+      // To use a realtime model instead of a voice pipeline, replace the LLM
+      // with a RealtimeModel and remove the STT/TTS from the AgentSession
+      // (Note: This is for the OpenAI Realtime API. For other providers, see https://docs.livekit.io/agents/models/realtime/)
+      // 1. Install '@livekit/agents-plugin-openai'
+      // 2. Set OPENAI_API_KEY in .env.local
+      // 3. Add `import * as openai from '@livekit/agents-plugin-openai'` to the top of this file
+      // 4. Replace the llm option with:
+      //    llm: new openai.realtime.RealtimeModel({ voice: 'marin' }),
 
       // To add tools, specify `tools` in the constructor.
       // Here's an example that adds a simple weather tool.

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import * as silero from '@livekit/agents-plugin-silero';
 import { audioEnhancement } from '@livekit/plugins-ai-coustics';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'node:url';
-import { AGENT_MODEL, Agent } from './agent';
+import { Agent } from './agent';
 
 // Load environment variables from a local file.
 // Make sure to set LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET
@@ -29,12 +29,6 @@ export default defineAgent<ProcessUserData>({
         language: 'multi',
       }),
 
-      // A Large Language Model (LLM) is your agent's brain, processing user input and generating a response
-      // See all providers at https://docs.livekit.io/agents/models/llm/
-      llm: new inference.LLM({
-        model: AGENT_MODEL,
-      }),
-
       // Text-to-speech (TTS) is your agent's voice, turning the LLM's text into speech that the user can hear
       // See all available models as well as voice selections at https://docs.livekit.io/agents/models/tts/
       tts: new inference.TTS({
@@ -51,16 +45,6 @@ export default defineAgent<ProcessUserData>({
         preemptiveGeneration: true,
       },
     });
-
-    // To use a realtime model instead of a voice pipeline, use the following session setup instead.
-    // (Note: This is for the OpenAI Realtime API. For other providers, see https://docs.livekit.io/agents/models/realtime/))
-    // 1. Install '@livekit/agents-plugin-openai'
-    // 2. Set OPENAI_API_KEY in .env.local
-    // 3. Add import `import * as openai from '@livekit/agents-plugin-openai'` to the top of this file
-    // 4. Use the following session setup instead of the version above
-    // const session = new voice.AgentSession({
-    //   llm: new openai.realtime.RealtimeModel({ voice: 'marin' }),
-    // });
 
     // Start the session, which initializes the voice pipeline and warms up the models
     await session.start({


### PR DESCRIPTION
this gets rid of the awkward AGENT_MODEL constant by just making the LLM an inherent property of the Assistant, which seems more intuitive

I also switched the test judge model to base 5.2 instead of the chat version to make it clearer that you can (and should) use a different model for evals than for core chat.

I'd like to move STT and TTS as well, but I found [a bug](https://live-kit.slack.com/archives/C05P6DRC6MV/p1777522751267209) we need to fix first

also see https://github.com/livekit-examples/agent-starter-python/pull/71