### PR TITLE
Fix Docker model cache path for cloud deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM node:${NODE_VERSION}-slim AS base
 # Configure pnpm installation directory and ensure it is on PATH
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+ENV HOME="/app"
 
 # Install required system packages and pnpm, then clean up the apt cache for a smaller image
 # ca-certificates: enables TLS/SSL for securely fetching dependencies and calling HTTPS services

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
-    "@livekit/agents": "^1.4.0",
-    "@livekit/agents-plugin-livekit": "^1.4.0",
-    "@livekit/agents-plugin-silero": "^1.4.0",
+    "@livekit/agents": "^1.4.1",
+    "@livekit/agents-plugin-livekit": "^1.4.1",
+    "@livekit/agents-plugin-silero": "^1.4.1",
     "@livekit/plugins-ai-coustics": "^0.2.12",
     "dotenv": "^17.4.1",
     "zod": "^3.25.76"


### PR DESCRIPTION
## Summary

Fixes Node agent cloud deployments where `pnpm download-files` succeeds during Docker build, but the worker later fails to find the LiveKit turn detector model at runtime.

The multi-stage Dockerfile runs `download-files` in the build stage as `root`, which caused HuggingFace/model files to be cached under `/root/.cache/huggingface`. Since the final image only copies `/app`, those files were missing at runtime when the app runs as `appuser` with home `/app`.

This sets `HOME=/app` in the shared base stage so build-time downloads and runtime model lookup use the same cache location under `/app`.

## Test plan

- Built the Docker image.
- Verified `pnpm download-files` writes model files under `/app/.cache/huggingface`.
- Verified the runtime container starts without `File not found in cache` for `livekit/turn-detector`.