### PR TITLE
Cache download-files in Dockerfile and simplify the download-files script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ COPY package.json pnpm-lock.yaml ./
 # --frozen-lockfile ensures we use exact versions from pnpm-lock.yaml for reproducible builds
 RUN pnpm install --frozen-lockfile
 
+# Pre-download any ML models or files the agent needs
+# This runs before COPY . . so the download layer is cached across code-only changes.
+# The standalone CLI discovers installed @livekit/agents-plugin-* packages without
+# loading your agent code.
+RUN pnpm download-files
+
 # Copy all remaining application files into the container
 # This includes source code, configuration files, and dependency specifications
 # (Excludes files specified in .dockerignore)
@@ -41,12 +47,6 @@ COPY . .
 # Build the project
 # Your package.json must contain a "build" script, such as `"build": "tsc"`
 RUN pnpm build
-
-# Pre-download any ML models or files the agent needs
-# This ensures the container is ready to run immediately without downloading
-# dependencies at runtime, which improves startup time and reliability
-# Your package.json must contain a "download-files" script, such as `"download-files": "pnpm run build && node dist/agent.js download-files"`
-RUN pnpm download-files
 
 # Remove dev dependencies for a leaner production image
 RUN pnpm prune --prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pnpm install --frozen-lockfile
 # This runs before COPY . . so the download layer is cached across code-only changes.
 # The standalone CLI discovers installed @livekit/agents-plugin-* packages without
 # loading your agent code.
-RUN pnpm download-files
+RUN npx livekit-agents download-files
 
 # Copy all remaining application files into the container
 # This includes source code, configuration files, and dependency specifications

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "dev": "pnpm run build && node dist/main.js dev",
-    "download-files": "npx livekit-agents download-files",
     "start": "node dist/main.js start"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "dev": "pnpm run build && node dist/main.js dev",
-    "download-files": "pnpm run build && npx livekit-agents download-files",
+    "download-files": "npx livekit-agents download-files",
     "start": "node dist/main.js start"
   },
   "engines": {


### PR DESCRIPTION
## Overview

Two related cleanups around `download-files`:

1. **Move the Dockerfile `download-files` step before `COPY . .`** so the download layer caches across code-only changes — editing your agent no longer triggers a re-download of plugin model files.
2. **Drop the redundant `pnpm run build &&` prefix** from the `download-files` script. The standalone `npx livekit-agents download-files` command (already referenced by this script) discovers installed `@livekit/agents-plugin-*` packages without loading your agent code, so the build step before it was a no-op.

## Changes

- **`Dockerfile`** — `RUN pnpm download-files` moved before `COPY . .` (was previously between `pnpm build` and `pnpm prune --prod`).
- **`package.json`** — `"download-files": "pnpm run build && npx livekit-agents download-files"` → `"download-files": "npx livekit-agents download-files"`.

`@livekit/agents` is pinned at `^1.4.3`, which is the version that introduced the standalone `livekit-agents download-files` CLI.

## Related PRs

This is part of a coordinated rollout across five repos. Each PR updates one slice of the same migration.

- Docs: livekit/web#4545
- CLI templates: livekit/livekit-cli#848
- Python starter: livekit-examples/agent-starter-python#79
- Node.js starter (this PR): livekit-examples/agent-starter-node#49
- Agent builder export: livekit/cloud-api-server#1847

Upstream SDK changes:

- Python: livekit/agents#5738 (livekit-agents@1.5.10)
- Node.js: livekit/agents-js#1511 (@livekit/agents@1.4.3)

