### PR TITLE
post_create: skip install hint when deps already installed

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -14,7 +14,7 @@ tasks:
       - echo 'To run the new agent locally:'
       - echo ''
       - echo '{{ indent .INDENT "cd" }} {{ .REL_PATH }}'
-      - echo '{{ indent .INDENT "pnpm install" }}'
+      - task: help_install_hint_if_needed
       - echo '{{ indent .INDENT "pnpm download-files" }}'
       - echo '{{ indent .INDENT "pnpm dev" }}'
       - echo ''
@@ -25,6 +25,14 @@ tasks:
       - echo ''
       - task: set_agent_name_if_present
       - task: help_open_sandbox_if_present
+
+  help_install_hint_if_needed:
+    desc: "Print the local install hint, unless the CLI already installed dependencies"
+    status:
+      # Skip when `lk agent init --install` already ran the install task.
+      - test -n "$LIVEKIT_DEPS_INSTALLED"
+    cmds:
+      - echo '{{ indent .INDENT "pnpm install" }}'
 
   set_agent_name_if_present:
     desc: "When LIVEKIT_AGENT_NAME is set, configure the agent to use it on init"


### PR DESCRIPTION
## Summary

When a user runs `lk agent init --install` (or answers "yes" to *Install dependencies?*), the CLI already runs the `install` task. The `post_create` "next steps" then still print `pnpm install`, which is redundant and confusing.

This moves the install hint into a small guarded subtask that is **skipped when the CLI already installed dependencies**, using the same `status:` pattern already used for `LIVEKIT_AGENT_NAME` / `LIVEKIT_SANDBOX_ID`.

```yaml
  post_create:
    cmds:
      ...
      - task: help_install_hint_if_needed   # was: echo '... pnpm install'
      ...

  help_install_hint_if_needed:
    status:
      - test -n "$LIVEKIT_DEPS_INSTALLED"    # skip when CLI already installed
    cmds:
      - echo '{{ indent .INDENT "pnpm install" }}'
```

The CLI sets `LIVEKIT_DEPS_INSTALLED=1` after a successful install (see livekit/livekit-cli#884). Until that CLI change ships, the var is simply never set, so behavior is unchanged.

## Behavior

| Scenario | `pnpm install` shown? |
| --- | --- |
| `lk agent init` (no install) | ✅ yes (unchanged) |
| `lk agent init --install` (success) | ❌ skipped |

## Testing

Verified end-to-end against a local CLI build: the hint is omitted on a successful `--install` and retained when install isn't run.

> Companion CLI PR: livekit/livekit-cli#884