### PR TITLE
Approve dependency build scripts so fresh clone is working

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@livekit/local-inference': true
+  protobufjs: true
+  sharp: true


### PR DESCRIPTION
## Problem

A fresh clone fails at, `pnpm run dev`, on any recent `pnpm`. Not super experienced with `pnpm` compared to `npm` so did some analysis on it.

> Since **pnpm 10.16**, `pnpm install` exits non-zero (`ERR_PNPM_IGNORED_BUILDS`) when a dependency has an unapproved build script. This template has three:

In our example that's:

- `@livekit/local-inference`
- `protobufjs`
- `sharp`

So on pnpm 10.16+ / 11, that deps check exits 1 and `pnpm run dev` aborts before the agent ever starts.

## Suggested Fix (AI Assisted)

Add a tracked `pnpm-workspace.yaml` that approves the three build scripts:

```yaml
allowBuilds:
  '@livekit/local-inference': true
  protobufjs: true
  sharp: true
```

These values don't all need to be true from my understanding but they need to be declared true or false.

Feel free to close if there's a better solution.